### PR TITLE
FHIR-54611 - Self-Referral Use Case Relevance

### DIFF
--- a/input/pagecontent/self_referral.md
+++ b/input/pagecontent/self_referral.md
@@ -9,6 +9,8 @@ This use case describes the scenario where an individual independently identifie
 
 The primary distinction from the provider-centric workflows described in this guide is that the **Individual/Patient** is the initiating actor. The system they use to make the request, a **Community Resource Platform**, acts as the technical **Referral Source** system. Consequently, the "closed loop" involves communicating referral disposition and outcomes back to this platform for the individual’s benefit, rather than to a clinical healthcare provider.
 
+This Self-Referral use case reflects a real-world scenario that happens today but is not yet handled in a standardized way. It was contributed by community members, and support for it is not required for conformance with this implementation guide. More generally, the use cases described throughout this guide are illustrative of common scenarios and are not an exhaustive catalog of all possible interactions within the SDOH ecosystem; implementers may apply the profiles and exchange patterns defined here to additional use cases that are not explicitly documented.
+
 
 ### Scope
 


### PR DESCRIPTION
Resolves ballot ticket **FHIR-54611** (Not Persuasive with Modification; Patient Care WG).

**Resolution:** "The Self-Referral use case was brought to us by community members. This use case is not required for implementers to support... We find this use case to be beneficial to the community... We are going to keep this use case within the guide. We will add some additional narrative that notates the use cases outlined in the IG are not exhaustive to all of the possible use cases in the SDOH ecosystem."

**Change:** adds one non-substantive clarifying paragraph to the Self-Referral page Overview (`input/pagecontent/self_referral.md`):
- the use case reflects a real-world scenario that happens today but is not yet handled in a standardized way;
- it was community-contributed and is optional (not required for conformance);
- the IG's use cases are illustrative, not an exhaustive catalog of all possible interactions in the SDOH ecosystem.

Narrative-only — no FSH/profile/example changes. Publisher QA unchanged vs baseline (errors 0, warnings 12, info 90, broken links 1).