### PR TITLE
FHIR-54906 - Statutes, Regulations, and Guiding Principles (SHOULD → SHALL)

### DIFF
--- a/input/pagecontent/privacy_and_security.md
+++ b/input/pagecontent/privacy_and_security.md
@@ -14,9 +14,9 @@ Entities covered under a BAA may be able to receive Protected Health Information
 All implementations of the SDOH ClinicalCare FHIR Implementation Guide (IG)
 * **SHALL** meet all current relevant Federal and State statutes and regulations regarding security and privacy.
 * **SHALL** use applicable technical standards required by current regulations published by CMS and ONC (allowing for voluntary use through the [Standards Version Advancement Process (SVAP)](https://www.healthit.gov/isa/standards-version-advancement-process#:~:text=ONC%20has%20established%20the%20voluntary,of%20Certification%20requirement%20(%C2%A7%20170.405))) unless an exception has been granted.
-* **SHOULD** follow the [Gravity Project Data Principles](https://confluence.hl7.org/display/GRAV/Gravity+Data+Principles) when the final version is published.
+* **SHALL** follow the [Gravity Project Data Principles](https://confluence.hl7.org/display/GRAV/Gravity+Data+Principles).
 * **SHALL** support patient/member consent and/or treatment of sensitive information consistent with Federal and State statutes and regulations.
-* **SHOULD** support the consent and data sharing policies of trading partners involved in the exchange that are more protective so long as policies are consistent with or more restrictive than Federal and State statutes and regulations.
+* **SHALL** support the consent and data sharing policies of trading partners involved in the exchange that are more protective so long as policies are consistent with or more restrictive than Federal and State statutes and regulations.
 
 ### FHIR Security and Implementation Guidance
 All implementations of the SDOH ClinicalCare FHIR Implementation Guide (IG) **SHOULD** follow the FHIR Security guidance and FHIR Implementer’s Safety guidance as defined in the relevant FHIR specification (e.g., Release 4.1.0) where applicable and not superseded by this Section or specific IG requirements.


### PR DESCRIPTION
Makes the requirements in the *Statutes, Regulations, and Guiding Principles* section of Privacy and Security consistently normative, per the ballot resolution:

- "SHOULD follow the Gravity Project Data Principles when the final version is published." → "**SHALL** follow the Gravity Project Data Principles." (the final principles are now published, so the conditional clause is removed).
- "SHOULD support the consent and data sharing policies of trading partners involved in the exchange…" → "**SHALL** support…".

All bullets in the section are now SHALL. Only `input/pagecontent/privacy_and_security.md` changes. Build QA unchanged from baseline (errors 0, warnings 12, hints 90, broken links 1).
