### PR TITLE
FHIR-55367 - Consistent Roles and Actors sections; referral source system is not assumed to be an EHR

### DIFF
--- a/input/pagecontent/capacity.md
+++ b/input/pagecontent/capacity.md
@@ -31,17 +31,22 @@ The following scenarios are out-of-scope at this time. This guide focuses on pro
 - **Organizational Capacity Reporting**: This use case does not cover high-level, aggregate capacity reporting that may occur as part of a contractual obligation between organizations (e.g., a quarterly report on service level agreements).
 
 
-### Actors and System
+### Roles and Actors
 
-#### Actors
+This use case uses the roles and actors defined in this Implementation Guide:
 
-This use case uses the existing actors defined in this Implementation Guide: **Referral Source**, **Coordination Platform**, and **Community-Based Organization (CBO)**.
+| Roles | Actors |
+| --- | --- |
+|**Referral Source**|Healthcare Provider|
+|**Referral Target**|CBO|
+|**Intermediary** (optional)|Coordination Platform (CP)|
+{:.grid}
 
 The most common scenario anticipated involves an indirect referral, where the **Referral Source** sends a referral to a **Coordination Platform**. The **Coordination Platform** then takes on the responsibility of checking for capacity with one or more **CBOs** before forwarding the referral.
 
 While less common, this guidance also supports the scenario where a **Referral Source** directly queries a **CBO** for its capacity status.
 
-#### System Environments
+### System Environments
 
 The interactions between actors can occur in different system environments. This IG is designed to support data exchange in **Open** and **Hybrid** systems.
 

--- a/input/pagecontent/enrollment.md
+++ b/input/pagecontent/enrollment.md
@@ -5,7 +5,7 @@
 
 ### Overview
 
-This page describes the use case, actors, systems, and information flows for sharing a patient's enrollment status in social care programs (e.g. SNAP). The exchange of this information is critical for effective care coordination, resource planning, and reducing administrative burden.
+This page describes the use case, roles, actors, and information flows for sharing a patient's enrollment status in social care programs (e.g. SNAP). The exchange of this information is critical for effective care coordination, resource planning, and reducing administrative burden.
 
 The primary goal of this use case is to enable healthcare providers and community-based organizations (CBOs) to share information about a person's or household’s enrollment status in social care programs. This exchange is intended to:
 
@@ -26,26 +26,24 @@ The determination of an individual's eligibility status for a program.
 The internal business process of determining if an individual is eligible for a program.
 
 
-### Actors and Systems
+### Roles and Actors
 
-The actors and systems involved in sharing program enrollment status are the same as those involved in the broader referral workflows.
+The roles and actors involved in sharing program enrollment status are the same as those involved in the broader referral workflows, and the systems they use mirror those workflows as well.
 
-#### Actors
+| Roles | Actors |
+| --- | --- |
+|**Referral Source**|Healthcare Provider|
+|**Referral Target**|CBO|
+|**Patient**|Patient|
+|**Intermediary** (optional)|Coordination Platform (CP)|
+{:.grid}
 
-- Provider: The healthcare entity or clinician that identifies a health-related social need (HRSN).
-- Community-Based Organization (CBO): The organization that receives referrals and provides social care services.
+- Provider: The healthcare entity or clinician that identifies a health-related social need (HRSN) and initiates referrals using a referral system — in many cases, but not necessarily, an EHR.
+- Community-Based Organization (CBO): The organization that receives referrals and provides social care services, using a system to manage referrals and service delivery.
 - Patient: The individual who is receiving care and whose enrollment status is being shared.
+- Coordination Platform (CP): The system that facilitates communication and data exchange between the provider and CBO, particularly in indirect referral scenarios. For example, an intermediary may operate the coordination platform that connects a Social Care Network (SCN).
 
 **NOTE:**  An individual who is enrolled in a program may be the point person for a service intended for an entire household.
-
-
-#### Systems
-
-The systems involved in the exchange mirror those in the established referral workflows and may include:
-
-- EHR System (Referral Source): The system used by the provider to manage patient care and initiate referrals.
-- CBO System (Referral Target): The system used by the CBO to manage referrals and service delivery.
-- Coordination Platform (CP): The system that facilitates communication and data exchange between the provider and CBO, particularly in indirect referral scenarios. For example, an intermediary may operate the coordination platform that connects a Social Care Network (SCN).
 
 
 ### Exchange Workflows

--- a/input/pagecontent/self_referral.md
+++ b/input/pagecontent/self_referral.md
@@ -26,11 +26,17 @@ This Self-Referral use case reflects a real-world scenario that happens today bu
 - The management of patient consent, which is assumed to be handled by the Community Resource Platform prior to initiating the referral workflow.
 
 
-### Actors and Systems
+### Roles and Actors
+
+| Roles | Actors |
+| --- | --- |
+|**Referral Source**|Individual/Patient, via a Community Resource Platform|
+|**Referral Target**|CBO|
+{:.grid}
 
 - **Individual/Patient**: A person or an authorized representative of a person with one or more health-related social needs who initiates a search and request for services. The person is the subject of the referral.
-- **Community Resource Platform**: A web-based application or service directory that enables individuals to search for social care services, complete screening assessments, and initiate referrals on their own behalf. In the context of the FHIR exchange, this platform functions as the **Referral Source system.
-- **Community-Based Organization (CBO)**: The organization that receives and acts upon the referral to provide a service. In the FHIR exchange, the CBO functions as the **Referral Recipient** system.
+- **Community Resource Platform**: A web-based application or service directory that enables individuals to search for social care services, complete screening assessments, and initiate referrals on their own behalf. In the context of the FHIR exchange, this platform functions as the **Referral Source** system.
+- **Community-Based Organization (CBO)**: The organization that receives and acts upon the referral to provide a service. In the FHIR exchange, the CBO functions as the **Referral Target** system.
 
 
 ### Exchange Workflow
@@ -47,7 +53,7 @@ This use case **exactly follows the exchange patterns defined in the Direct Refe
 1. The individual completes an SDOH screening questionnaire on the Community Resource Platform.
 2. Based on the screening results, the platform displays a list of suitable CBOs.
 3. The individual selects a CBO to which they wish to be referred.
-4. The **Community Resource Platform** (acting as the Referral Source) creates the [SDOHCC ServiceRequest](StructureDefinition-SDOHCC-ServiceRequest.html) and related resources and then POSTs a Task resource to the **CBO's** (Referral Recipient's) FHIR server endpoint.
+4. The **Community Resource Platform** (acting as the Referral Source) creates the [SDOHCC ServiceRequest](StructureDefinition-SDOHCC-ServiceRequest.html) and related resources and then POSTs a Task resource to the **CBO's** (Referral Target's) FHIR server endpoint.
 5. The CBO's system processes the received Task and retrieves the referenced [SDOHCC ServiceRequest](StructureDefinition-SDOHCC-ServiceRequest.html) and Patient resources from the Community Resource Platform's server to get the full referral details. It then updates the status of the [SDOHCC Task For Referral Management](StructureDefinition-SDOHCC-TaskForReferralManagement.html) on its own server (e.g., from 'requested' to 'accepted').
 6. The **Community Resource Platform** periodically queries (`GET`) the Task on the CBO's server to check for status changes.
 7. As the CBO works the referral, it continues to update the Task on its server (e.g., to 'in-progress' and finally 'completed' or 'cancelled'). Upon completion, it adds references in Task.output to resources detailing the outcome (e.g., an [SDOHCC Procedure](StructureDefinition-SDOHCC-Procedure.html)).


### PR DESCRIPTION
Implements [FHIR-55367](https://jira.hl7.org/browse/FHIR-55367) (Persuasive with Modification): per the resolution, the four new narrative pages now use a consistent **Roles and Actors** section — the RFFA page already had one; this PR brings Enrollment, Capacity, and Self-Referral in line, folding the systems into the actor descriptions and using the shared Roles/Actors table pattern.

**Changes:**
- **Enrollment** — the *Actors*/*Systems* subsections merge into one *Roles and Actors* section (table + actor descriptions). The referral source's system is now described as **"a referral system — in many cases, but not necessarily, an EHR"** (the ticket's core recommendation). The household NOTE and the Social Care Network (SCN) context are preserved.
- **Capacity** — *Actors and System* (heading typo included) becomes *Roles and Actors* with the shared table; the two workflow-scenario paragraphs remain as prose. *System Environments* (Closed/Open/Hybrid — a deployment-topology concept, not workflow participants) is promoted to its own section. The table intentionally has no Patient row: the capacity query exchanges no identifying information about an individual, and the capacity diagrams have no patient lane.
- **Self-Referral** — *Actors and Systems* becomes *Roles and Actors* with the table (no Intermediary row — the use case follows the Direct Referral pattern). Narrative role naming normalized: **"Referral Recipient" → "Referral Target"** (CapabilityStatement artifact names are unchanged). Also fixes an unclosed bold in the Community Resource Platform bullet.
- **RFFA** — no changes needed; it already matches the resolution.

For the ticket's note that the EHR assumption "may exist in other parts of the spec as well": occurrences outside these four pages (e.g., on the Checking Task Status page and in the index) are inventoried on the Jira ticket for separate consideration, as the resolution scoped this change to the four narrative pages.

**QA:** unchanged vs master baseline — 1 error / 10 warnings / 90 hints / 0 broken links (the single error is the known environmental tx.fhir.org cache failure, present on unmodified master).